### PR TITLE
Add git to built image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_install:
 install:
   - rm -rf ./src/
   - git clone https://github.com/danielperna84/hass-configurator.git ./src
+  - sed -i 's/GIT = False/GIT = True/g' ./src/configurator.py
 
 script:
   - docker run --rm --privileged multiarch/qemu-user-static:register

--- a/Dockerfile.amd64
+++ b/Dockerfile.amd64
@@ -1,6 +1,11 @@
 FROM python:3-alpine
 MAINTAINER Martin <Munsio> Treml
 
+RUN apk update && apk upgrade && \
+    apk add --no-cache bash git openssh
+
+RUN pip install --no-cache-dir gitpython
+
 WORKDIR /app
 COPY ./src/configurator.py ./run.sh /app/
 RUN chmod a+x ./configurator.py ./run.sh

--- a/Dockerfile.rpi
+++ b/Dockerfile.rpi
@@ -1,6 +1,11 @@
 FROM mielune/alpine-python3-arm
 MAINTAINER Martin <Munsio> Treml
 
+RUN apk update && apk upgrade && \
+    apk add --no-cache bash git openssh
+
+RUN pip install --no-cache-dir gitpython
+
 WORKDIR /app
 COPY ./src/configurator.py ./run.sh /app/
 RUN chmod a+x ./configurator.py ./run.sh


### PR DESCRIPTION
This makes it possible to use the git functionality offered by the configurator.

To authenticate with a git server, ssh keys can be mounted to /root/.ssh 
This should include id_rsa, id_rsa.pub and known_hosts