### PR TITLE
updating docker tags to use semantic versioning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ services:
 
 before_install:
   - VERSION=`cat VERSION`
-  - DOCKER_BUILD=causticlab/hass-configurator-docker:${ARCH}-${VERSION}
+  - DOCKER_BUILD=causticlab/hass-configurator-docker:${VERSION}-${ARCH}
 
 install:
   - rm -rf ./src/


### PR DESCRIPTION
The purpose of this PR is to alter the way by which the docker images are tagged to follow [semantic versioning](https://semver.org/) rules such that instead of an image being tagged `x86_64-0.3.3` it would instead be tagged `0.3.3-x86_64`.

The reason for this change is to allow automations which use semantic versioning rules to identify new versions (e.g. [keel](https://keel.sh/)) to operate properly.

Signed-off-by: Jeff Billimek <jeff@billimek.com>